### PR TITLE
Add equation varaition with state

### DIFF
--- a/materials/property.py
+++ b/materials/property.py
@@ -27,8 +27,7 @@ class StateDependentProperty(Property):
         Property.__init__(self, name, yaml_dict)
         self.variations_with_state = {}
         for vs_name, vs_subdict in yaml_dict['variations_with_state'].items():
-            if vs_subdict['representation'] == 'table':
-                self.variations_with_state[vs_name] = vstate.build_from_yaml(vs_subdict)
+            self.variations_with_state[vs_name] = vstate.build_from_yaml(vs_subdict)
         self.default_state_model = list(self.variations_with_state.keys())[0]
 
     def query_value(self, state, state_model=None, model_args_dict=None):

--- a/materials/property_test.py
+++ b/materials/property_test.py
@@ -171,7 +171,7 @@ class TestStateDependentProperty(unittest.TestCase):
                     'value_type': 'multiplier',
                     'representation': 'equation',
                     'reference': 'reference',
-                    'expression': 'temperature**2',
+                    'expression': 'value = temperature**2',
                     'state_domain': {'temperature': (0, 1000)},
                 }
             }

--- a/materials/property_test.py
+++ b/materials/property_test.py
@@ -156,6 +156,36 @@ class TestStateDependentProperty(unittest.TestCase):
         with self.assertRaises(ValueError):
             prop.query_value({'fish': 1., 'exposure time': 1})    # fish is not a state variable.
 
+    def test_query_1d_eqn(self):
+        """Test query_value with a single varaible equation."""
+        # Setup
+        dv = 2.0
+        yaml_dict = {
+            'default_value': dv,
+            'units': 'MPa',
+            'reference': 'mmpds',
+            'variations_with_state': {
+                'thermal': {
+                    'state_vars': ['temperature'],
+                    'state_vars_units': {'temperature': 'kelvin'},
+                    'value_type': 'multiplier',
+                    'representation': 'equation',
+                    'reference': 'reference',
+                    'expression': 'temperature**2',
+                    'state_domain': {'temperature': (0, 1000)},
+                }
+            }
+        }
+        prop = StateDependentProperty('name', yaml_dict)
+
+        # Action and verification
+        # Check good queries
+        self.assertEqual(prop.query_value({'temperature': 1}), 1**2 * dv)
+        self.assertEqual(prop.query_value({'temperature': 2}), 2**2 * dv)
+        # Check bad query
+        with self.assertRaises(ValueError):
+            prop.query_value({'fish': 1.})    # fish is not a state variable.
+
 
     def test_getitem(self):
         """Unit test for __getitem__"""

--- a/materials/variation_with_state_test.py
+++ b/materials/variation_with_state_test.py
@@ -115,7 +115,7 @@ class TestBuildFromYaml(unittest.TestCase):
             'value_type': 'multiplier',
             'representation': 'equation',
             'reference': 'reference',
-            'expression': '1 + temperature**2',
+            'expression': 'value = 1 + temperature**2',
             'state_domain': {'temperature': (0, 1000)},
             }
 
@@ -368,5 +368,16 @@ class TestVariationWithStateEquation(unittest.TestCase):
         self.assertFalse(state_model.is_state_in_domain({'temperature': 1000.1, 'pressure': 1}))
         self.assertFalse(state_model.is_state_in_domain({'temperature': 10, 'pressure': -1}))
 
+    def test_import_os(self):
+        """Security: Make sure one cannot import os in the expression."""
+        # Setup
+        state_model = vstate.VariationWithStateEquation(
+            ['temperature'], {'temperature': 'kelvin'}, 'override', 'reference',
+            'value = 1; import os', {'temperature': (0, 1000)})
+        # Action and verification
+        with self.assertRaises(NotImplementedError):
+            state_model.query_value({'temperature': 1})
+
+ 
 if __name__ == '__main__':
     unittest.main()

--- a/materials/variation_with_state_test.py
+++ b/materials/variation_with_state_test.py
@@ -320,7 +320,7 @@ class TestVariationWithStateEquation(unittest.TestCase):
         # Setup
         state_model = vstate.VariationWithStateEquation(
             ['temperature'], {'temperature': 'kelvin'}, 'override', 'reference',
-            '1 + temperature**2', {'temperature': (0, 1000)})
+            'value = 1 + temperature**2', {'temperature': (0, 1000)})
 
         # Action and verification
         result = state_model.query_value({'temperature': 1})
@@ -333,7 +333,7 @@ class TestVariationWithStateEquation(unittest.TestCase):
         # Setup
         state_model = vstate.VariationWithStateEquation(
             ['temperature'], {'temperature': 'kelvin'}, 'override', 'reference',
-            '1 + temperature**2', {'temperature': (0, 1000)})
+            'value = 1 + temperature**2', {'temperature': (0, 1000)})
 
         # Action and verification
         self.assertTrue(state_model.is_state_in_domain({'temperature': 1}))
@@ -346,7 +346,7 @@ class TestVariationWithStateEquation(unittest.TestCase):
         state_model = vstate.VariationWithStateEquation(
             ['temperature', 'pressure'], {'temperature': 'kelvin', 'pressure': 'pascal'},
             'override', 'reference',
-            '1 + temperature**2 + pressure', {'temperature': (0, 1000), 'pressure': (0, 1e6)})
+            'value = 1 + temperature**2 + pressure', {'temperature': (0, 1000), 'pressure': (0, 1e6)})
 
         # Action and verification
         result = state_model.query_value({'temperature': 1, 'pressure': 1})
@@ -360,7 +360,7 @@ class TestVariationWithStateEquation(unittest.TestCase):
         state_model = vstate.VariationWithStateEquation(
             ['temperature', 'pressure'], {'temperature': 'kelvin', 'pressure': 'pascal'},
             'override', 'reference',
-            '1 + temperature**2 + pressure', {'temperature': (0, 1000), 'pressure': (0, 1e6)})
+            'value = 1 + temperature**2 + pressure', {'temperature': (0, 1000), 'pressure': (0, 1e6)})
 
         # Action and verification
         self.assertTrue(state_model.is_state_in_domain({'temperature': 1, 'pressure': 1}))

--- a/materials_data/copper.yaml
+++ b/materials_data/copper.yaml
@@ -1,0 +1,93 @@
+name: copper
+category: metal
+subcategory: 'copper and copper alloys'
+
+references:    # In bibtex format
+  - |
+    @article{matula1979,
+      author = {R A Matula},
+      title = {Electrical Resistivity of Copper, Gold, Palladium, and Silver},
+      journal = {J. Phys. Chem. Ref. Data},
+      year = {1979},
+      volume = {8},
+      number = {4},
+      url = {https://srd.nist.gov/JPCRD/jpcrd155.pdf}
+    }
+  - |
+    @online{nist_webook_copper,
+      author = {{National Institute of Standards and Technology}},
+      title = {copper},
+      year = {2018},
+      url = {https://webbook.nist.gov/cgi/cbook.cgi?ID=C7440508}
+    }
+
+elemental_composition:    # percent by mass, [min, max]
+  Cu: [99.999, 100.]
+
+common_properties: &common_properties
+  melting_point:
+    units: kelvin
+    default_value: 1357.95
+    reference: nist_webook_copper
+  heat_capacity:
+    units: 'joule kilogram**-1 kelvin**-1'
+    default_value: 385.1
+    reference: nist_webook_copper
+    variations_with_state:
+      thermal:
+        state_vars: ['temperature']
+        state_vars_units: {'temperature': 'kelvin'}
+        value_type: override    # multiplier or override
+        representation: equation
+        reference: nist_webook_copper
+        expression: 't = temperature / 1000; value = (1/ 0.063546) * (17.72891 + 28.09870 * t + -31.25289 * t**2 + 13.97243 * t**3 + 0.068611 * t**(-2))'
+        state_domain:
+          temperature: [298, 1358]
+  electrical_resistivity:
+    units: 'ohm meter'
+    default_value: 1.678e-8
+    reference: matula1979
+    variations_with_state:
+      thermal:
+        state_vars: ['temperature']
+        state_vars_units: {'temperature': 'kelvin'}
+        state_vars_interp_scales: ['log']
+        value_type: override    # multiplier or override
+        representation: 'table'
+        reference: matula1979
+        temperature: [1, 4, 7, 10, 15,
+          20, 25, 30, 35, 40,
+          45, 50, 55, 60, 70,
+          80, 90, 100, 125, 150,
+          175, 200, 225, 250, 273.15,
+          293, 300, 350, 400, 500,
+          600, 700, 800, 900, 1000,
+          1100, 1200, 1300, 1357.6]
+        values: [0.002e-8, 0.002e-8, 0.002e-8, 0.00202e-8, 0.00218e-8,
+          0.00280e-8, 0.00449e-8, 0.00828e-8, 0.0147e-8, 0.0239e-8,
+          0.0358e-8, 0.0518e-8, 0.0727e-8, 0.0971e-8, 0.154e-8,
+          0.215e-8, 0.281e-8, 0.348e-8, 0.522e-8, 0.699e-8,
+          0.874e-8, 1.046e-8, 1.217e-8, 1.387e-8, 1.543e-8,
+          1.678e-8, 1.725e-8, 2.063e-8, 2.402e-8, 3.090e-8,
+          3.792e-8, 4.514e-8, 5.262e-8, 6.041e-8, 6.858e-8,
+          7.717e-8, 8.626e-8, 9.592e-8, 10.171e-8]
+forms:
+  # This map gives different forms in which the material can produced,
+  # e.g. 'extruded', 'forged', etc. We use form in the same sense as MMPDS.
+  #
+  # Within each form, the `conditions` map,  gives different conditions,
+  # a.k.a heat treatments or tempers, that can be applied to the material.
+  # MMPDS uses the terms 'condition' and 'temper' to refer to this concept.
+  #
+  # The form and condition can effect some properties of the material, so there is a
+  # separate `properties` map within each form and condition.
+  'wire':
+    conditions:
+      'annealed':
+        properties:
+          # The `<<: *x` is YAML magic which copies all the keys of `x`
+          # into the current map.
+          # See https://learnxinyminutes.com/docs/yaml/
+          # This allows us to copy common properties into each form & condition
+          # that share those properties.
+          <<: *common_properties

--- a/tutorials/copper_demo.py
+++ b/tutorials/copper_demo.py
@@ -1,0 +1,42 @@
+import os.path
+import numpy as np
+import matplotlib.pyplot as plt
+import materials
+from materials import plot_utils
+
+def main():
+    # Load copper properties from the data file
+    filename = os.path.join(materials.get_database_dir(), 'copper.yaml')
+    copper = materials.load_from_yaml(filename, 'wire', 'annealed')
+
+    # Print a summary of the available properties for copper
+    print(copper)
+
+    # Query the heat capacity
+    cp_300 = copper['heat_capacity'].query_value({'temperature': 300})
+    print('Heat capacity of copper at 300 K = {:.1f} {:s}'.format(
+        cp_300, copper['heat_capacity'].units))
+
+    # Query the resistivity at several temperatures
+    temp = np.linspace(100, 600, 6)
+    rho = copper['electrical_resistivity'].query_value({'temperature': temp})
+    print('Electrical resistivity of copper:')
+    print('temperature: ' + str(temp) + ' K')
+    print('resistivity: ' + str(rho) + copper['electrical_resistivity'].units)
+
+    # Make plots
+    plt.figure(figsize=(6, 8))
+    ax1 = plt.subplot(2, 1, 1)
+    plot_utils.plot_property_vs_state(
+        copper['electrical_resistivity'], 'thermal', 'temperature', axes=ax1)
+    ax2 = plt.subplot(2, 1, 2, sharex=ax1)
+    plot_utils.plot_property_vs_state(
+        copper['heat_capacity'], 'thermal', 'temperature', axes=ax2)
+
+    plt.suptitle('Electrical resistivity and heat capacity of pure copper')
+    plt.tight_layout()
+    plt.subplots_adjust(top=0.90)
+    plt.show()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Add the capability to represent variations with state as an equation which gives the property value as a function of the state variables.

This is useful, e.g. for including heat capacities from the NIST webbook, which are given using the Shomate equation.

The equation string from the config file is parsed into python code using `asteval`: https://newville.github.io/asteval/

This also includes a demo of representing the heat capacity of copper using an equation, see `copper.yaml` and `copper_demo.py`. (I chose copper because James wanted copper properties for his magnet coil project.)